### PR TITLE
rules: fix typo 'middelware_has_udpate' in `templates/rules/sources.h…

### DIFF
--- a/rules/templates/rules/sources.html
+++ b/rules/templates/rules/sources.html
@@ -138,7 +138,7 @@ function UpdateSource{{ source.id }}() {
         <h4 class="modal-title" id="UpdateModalLabel">Please wait...</h4>
       </div>
       <div class="modal-body" id="update_text">
-{% if middleware_has_udpate %}
+{% if middleware_has_update %}
         Triggering source update. This window will close when operation is registered.
 {% else %}
         Scirius is updating source. This window will close when update is over.


### PR DESCRIPTION
This PR fixes a typo in `rules/templates/rules/sources.html`.